### PR TITLE
fix how to setting axis

### DIFF
--- a/src/settings.html
+++ b/src/settings.html
@@ -839,7 +839,7 @@
                     <ol>
                         <li><a href="https://axis.prioris.jp/">Axisのサイト</a>にアクセス</li>
                         <li>ユーザー登録</li>
-                        <li>［Access Token］ のページから、[jmx-seismology]と[eew]の２つのチャンネルを選択</li>
+                        <li>［Channel］ のページから、[jmx-seismology]と[eew]の２つのチャンネルを選択</li>
                         <li>［Access Token］ のページからアクセストークンを確認</li>
                     </ol>
 


### PR DESCRIPTION
## 概要

Axisの設定方法の箇所が現状のAxisのサイトと異なっていたため修正
![image](https://github.com/0Quake/Zero-Quake/assets/13718335/fdd9e8d1-630f-48d1-956d-bcfd78fabb90)

## 変更点

Access TokenをChannelに変更

## 関連するIssue

なし
