### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -9,6 +9,9 @@
 
 name: ESLint
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/0Quake/Zero-Quake/security/code-scanning/9](https://github.com/0Quake/Zero-Quake/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only runs ESLint checks and does not perform any write operations, the minimal permissions required are `contents: read`. This will restrict the `GITHUB_TOKEN` to read-only access to the repository contents, ensuring that the workflow adheres to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
